### PR TITLE
fix header size in Safari browser, issue with flexbox

### DIFF
--- a/src/components/header/header.css
+++ b/src/components/header/header.css
@@ -21,7 +21,7 @@
 
   & img {
     width: 60px;
-    margin-right: 1rem;
+    margin: 1rem 1rem 1rem 0;
   }
 
   @media (max-width: 768px) {
@@ -32,9 +32,11 @@
     }
     h2 {
       font-size: 22px;
+      margin-top: auto;
     }
     img {
-      width: 40px;
+      width: 30px;
+      margin: 0 0.5rem 0 0;
     }
     #brand-header {
       justify-content: center;

--- a/src/components/header/header.js
+++ b/src/components/header/header.js
@@ -14,7 +14,9 @@ class HeaderComponent extends LitElement {
 
       <header>
         <div id="brand-header">
-          <img src="${evergreenLogo}"  alt="project evergreen logo" />
+          <div>
+            <img src="${evergreenLogo}"  alt="project evergreen logo" />
+          </div>
           <h2 class="header-text">
             Project Evergreen
           </h2>


### PR DESCRIPTION
I noticed an issue with the header rendering oddly in Safari, was a flex box issue 