### PR TITLE
fix redundant tagline for greenwood in projects

### DIFF
--- a/src/components/projects-list/projects-list.js
+++ b/src/components/projects-list/projects-list.js
@@ -1,6 +1,6 @@
 const projects = [{
   name: 'Greenwood',
-  description: 'A modern and performance static site generator for the modern web.',
+  description: 'A modern and performant static site generator supporting Web Component based development.',
   image: '/assets/projects/greenwood-logo-500w.png',
   github: 'ProjectEvergreen/greenwood',
   website: 'https://www.greenwoodjs.io/'


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
N / A

## Summary of Changes
1. The current tagline for **Greenwood** is a bit redundant, so for now, just mirroring the tagline from the project itself.