### PR TITLE
upgrade v0.25.0

### DIFF
--- a/greenwood.config.js
+++ b/greenwood.config.js
@@ -2,28 +2,8 @@ import { greenwoodPluginGoogleAnalytics } from '@greenwood/plugin-google-analyti
 import { greenwoodPluginImportCss } from '@greenwood/plugin-import-css';
 import { greenwoodPluginPostCss } from '@greenwood/plugin-postcss';
 
-const FAVICON_HREF = '/assets/favicon.ico';
-const HANDLE = '@PrjEvergreen';
-const META_DESCRIPTION = 'Project Evergreen\'s goal is to help everyone succeed in making a modern website or application using the latest in web standards and technologies.';
-
 export default {
-  title: 'Project Evergreen',
-
   prerender: true,
-
-  meta: [
-    { name: 'description', content: META_DESCRIPTION },
-    { name: 'twitter:site', content: HANDLE },
-    { name: 'twitter:creator', content: HANDLE },
-    { property: 'og:title', content: 'Project Evergreen' },
-    { property: 'og:type', content: 'website' },
-    { property: 'og:url', content: 'https://projectevergreen.github.io' },
-    { property: 'og:image', content: 'https://projectevergreen.github.io/assets/evergreen-logo.png' },
-    { property: 'og:description', content: META_DESCRIPTION },
-    { rel: 'shortcut icon', href: FAVICON_HREF },
-    { rel: 'icon', href: FAVICON_HREF },
-    { name: 'google-site-verification', content: 'KWcqT8r7R4bo7MjTwPtmAsZ079gqb7wAXeFkIJQJzs0' }
-  ],
 
   plugins: [
     greenwoodPluginPostCss(),
@@ -34,5 +14,4 @@ export default {
       analyticsId: 'UA-147204327-2'
     })
   ]
-
 };

--- a/greenwood.config.js
+++ b/greenwood.config.js
@@ -9,6 +9,8 @@ const META_DESCRIPTION = 'Project Evergreen\'s goal is to help everyone succeed 
 export default {
   title: 'Project Evergreen',
 
+  prerender: true,
+
   meta: [
     { name: 'description', content: META_DESCRIPTION },
     { name: 'twitter:site', content: HANDLE },

--- a/package.json
+++ b/package.json
@@ -18,12 +18,13 @@
     "lit-element": "^2.4.0"
   },
   "devDependencies": {
-    "@greenwood/cli": "^0.25.0-alpha.0",
-    "@greenwood/plugin-google-analytics": "^0.25.0-alpha.0",
-    "@greenwood/plugin-import-css": "^0.25.0-alpha.0",
-    "@greenwood/plugin-postcss": "^0.25.0-alpha.0",
+    "@greenwood/cli": "^0.25.0-alpha.1",
+    "@greenwood/plugin-google-analytics": "^0.25.0-alpha.1",
+    "@greenwood/plugin-import-css": "^0.25.0-alpha.1",
+    "@greenwood/plugin-postcss": "^0.25.0-alpha.1",
     "eslint": "^8.4.0",
     "postcss-nested": "^4.1.2",
+    "puppeteer": "^10.2.0",
     "rimraf": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
     "lit-element": "^2.4.0"
   },
   "devDependencies": {
-    "@greenwood/cli": "^0.25.0-alpha.3",
-    "@greenwood/plugin-google-analytics": "^0.25.0-alpha.3",
-    "@greenwood/plugin-import-css": "^0.25.0-alpha.3",
-    "@greenwood/plugin-postcss": "^0.25.0-alpha.3",
+    "@greenwood/cli": "^0.25.0",
+    "@greenwood/plugin-google-analytics": "^0.25.0",
+    "@greenwood/plugin-import-css": "^0.25.0",
+    "@greenwood/plugin-postcss": "^0.25.0",
     "eslint": "^8.4.0",
     "postcss-nested": "^4.1.2",
     "puppeteer": "^10.2.0",

--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
     "lit-element": "^2.4.0"
   },
   "devDependencies": {
-    "@greenwood/cli": "^0.25.0-alpha.1",
-    "@greenwood/plugin-google-analytics": "^0.25.0-alpha.1",
-    "@greenwood/plugin-import-css": "^0.25.0-alpha.1",
-    "@greenwood/plugin-postcss": "^0.25.0-alpha.1",
+    "@greenwood/cli": "^0.25.0-alpha.2",
+    "@greenwood/plugin-google-analytics": "^0.25.0-alpha.2",
+    "@greenwood/plugin-import-css": "^0.25.0-alpha.2",
+    "@greenwood/plugin-postcss": "^0.25.0-alpha.2",
     "eslint": "^8.4.0",
     "postcss-nested": "^4.1.2",
     "puppeteer": "^10.2.0",

--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
     "lit-element": "^2.4.0"
   },
   "devDependencies": {
-    "@greenwood/cli": "^0.25.0-alpha.2",
-    "@greenwood/plugin-google-analytics": "^0.25.0-alpha.2",
-    "@greenwood/plugin-import-css": "^0.25.0-alpha.2",
-    "@greenwood/plugin-postcss": "^0.25.0-alpha.2",
+    "@greenwood/cli": "^0.25.0-alpha.3",
+    "@greenwood/plugin-google-analytics": "^0.25.0-alpha.3",
+    "@greenwood/plugin-import-css": "^0.25.0-alpha.3",
+    "@greenwood/plugin-postcss": "^0.25.0-alpha.3",
     "eslint": "^8.4.0",
     "postcss-nested": "^4.1.2",
     "puppeteer": "^10.2.0",

--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
     "lit-element": "^2.4.0"
   },
   "devDependencies": {
-    "@greenwood/cli": "^0.23.0",
-    "@greenwood/plugin-google-analytics": "^0.23.0",
-    "@greenwood/plugin-import-css": "^0.23.0",
-    "@greenwood/plugin-postcss": "^0.23.0",
+    "@greenwood/cli": "^0.25.0-alpha.0",
+    "@greenwood/plugin-google-analytics": "^0.25.0-alpha.0",
+    "@greenwood/plugin-import-css": "^0.25.0-alpha.0",
+    "@greenwood/plugin-postcss": "^0.25.0-alpha.0",
     "eslint": "^8.4.0",
     "postcss-nested": "^4.1.2",
     "rimraf": "^3.0.0"

--- a/src/templates/app.html
+++ b/src/templates/app.html
@@ -1,10 +1,21 @@
 <!DOCTYPE html>
 <html lang="en" prefix="og:http://ogp.me/ns#">
   <head>
+    <title>Project Evergreen</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <meta name="mobile-web-app-capable" content="yes"/>
-    <meta-outlet></meta-outlet>
+    <meta name="description" content="Project Evergreen's goal is to help everyone succeed in making a modern website or application using the latest in web standards and technologies.">
+    <meta name="twitter:site" content="@PrjEvergreen">
+    <meta name="twitter:creator" content="@PrjEvergreen">
+    <meta property="og:title" content="Project Evergreen">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://projectevergreen.github.io">
+    <meta property="og:image" content="https://projectevergreen.github.io/assets/evergreen-logo.png">
+    <meta property="og:description" content="Project Evergreen's goal is to help everyone succeed in making a modern website or application using the latest in web standards and technologies.">
+    <meta name="google-site-verification" content="KWcqT8r7R4bo7MjTwPtmAsZ079gqb7wAXeFkIJQJzs0">
+    <link rel="shortcut icon" href="/assets/favicon.ico">
+    <link rel="icon" href="/assets/favicon.ico">
 
     <link rel="stylesheet" href="/styles/theme.css"></link>
     

--- a/yarn.lock
+++ b/yarn.lock
@@ -43,10 +43,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@greenwood/cli@^0.25.0-alpha.1":
-  version "0.25.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@greenwood/cli/-/cli-0.25.0-alpha.1.tgz#a4e3392478bfd9d1e81cf88409433bc512078cad"
-  integrity sha512-sMd92MWcQ4AVEWhCpjp1fFgtxJ08RbRAy+F512rJ7czLOdsA/6HwKa70CbfWpObQ0Bv/t6/YXGE/V+DkT5rWkA==
+"@greenwood/cli@^0.25.0-alpha.2":
+  version "0.25.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@greenwood/cli/-/cli-0.25.0-alpha.2.tgz#a9a62aca5603799c12944750a37418a70add5b01"
+  integrity sha512-VZBMCJBABXG3pa4nY4WAB2nr7hORuQcKhqMf6lPELt2mOu6aP3WnYFgxxV6VqDsdPzs/eHF8A2pBgLQrUIzkNw==
   dependencies:
     "@rollup/plugin-node-resolve" "^13.0.0"
     "@rollup/plugin-replace" "^2.3.4"
@@ -73,22 +73,22 @@
     rollup-plugin-terser "^7.0.0"
     unified "^9.2.0"
 
-"@greenwood/plugin-google-analytics@^0.25.0-alpha.1":
-  version "0.25.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@greenwood/plugin-google-analytics/-/plugin-google-analytics-0.25.0-alpha.1.tgz#ab256ee71381ea6fb41e5b70842f48081949b4d5"
-  integrity sha512-EI4mjsyXMs7rZv2PpUbmFRvZl+cGwTmxepErbzRCaXn128aFhfpa31UgLSdecAazR+Ulw9TKRlJ3+PT5BKrteg==
+"@greenwood/plugin-google-analytics@^0.25.0-alpha.2":
+  version "0.25.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@greenwood/plugin-google-analytics/-/plugin-google-analytics-0.25.0-alpha.2.tgz#9bc51fe7fc49afd6a42b387681590f471ed36baf"
+  integrity sha512-T9E4pplzkpkeLsc3mRBuucYGvyLPN9h1em4FOmqnAqK7uK6lj3hU8SjR1KGPmujo0z6o7jmYe3sCWbu+vEvUng==
 
-"@greenwood/plugin-import-css@^0.25.0-alpha.1":
-  version "0.25.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@greenwood/plugin-import-css/-/plugin-import-css-0.25.0-alpha.1.tgz#e01fe6a783369d343f966267d73af76d63a93a8d"
-  integrity sha512-uqlwZnOPC6iwUpmnW6Gp9Yq7+JWCNn5j6DfCTkHQHnGIpsxkVGsbzW8RCzTh734X+Pahel/40qzSIkhFvJRIOw==
+"@greenwood/plugin-import-css@^0.25.0-alpha.2":
+  version "0.25.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@greenwood/plugin-import-css/-/plugin-import-css-0.25.0-alpha.2.tgz#783fbd0ea0fb3b9f2077834da9c5ce0ba72d8f29"
+  integrity sha512-+3nFA3diP9fhFSX8wc8N1nSAdJP2ZPnC7c2+XfJaYAAo2F681nOwiFQYWBY3M5IFayR3ToJIQJsTbTqtqdqEUQ==
   dependencies:
     rollup-plugin-postcss "^4.0.2"
 
-"@greenwood/plugin-postcss@^0.25.0-alpha.1":
-  version "0.25.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@greenwood/plugin-postcss/-/plugin-postcss-0.25.0-alpha.1.tgz#b63a79e56635a6bc05ae99548773d0ed6fc5a6a8"
-  integrity sha512-88Ub+RRBqWjZSbVywpWWXT7p8seEDdZVVil+afLxD5m9oMVwqnqFZ/dUZWuVUHSWDpy0VKi+gE21VxM/DCevJQ==
+"@greenwood/plugin-postcss@^0.25.0-alpha.2":
+  version "0.25.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@greenwood/plugin-postcss/-/plugin-postcss-0.25.0-alpha.2.tgz#8e385ca0ccda5e2fe10645684883354e70388075"
+  integrity sha512-6/SYwSlfmeic44N3wSdJSVc/kh5/mMF4YIQQC1b0agiylcirQM1LgnEaHZooDX3J0dcC16eEgmY7ZL/0+EthBA==
   dependencies:
     cssnano "^5.0.11"
     postcss-preset-env "^7.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -43,10 +43,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@greenwood/cli@^0.25.0-alpha.3":
-  version "0.25.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/@greenwood/cli/-/cli-0.25.0-alpha.3.tgz#0ed44008d99196e10a0fbba6d1800bfbabf8d3e6"
-  integrity sha512-KHpaBnNhsJD3DjTf5I1ssZ8zsOVt+IHy+W/pJvf687oUbOTtVvXFdaRLHuEDUBwEq8L6Rqc0vMp9hDCXqKtVHw==
+"@greenwood/cli@^0.25.0":
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/@greenwood/cli/-/cli-0.25.0.tgz#b0b29513258a3009bbe7e7cca92874a056501fb5"
+  integrity sha512-JIsgYMPTkdNgCN8GtG9Us/g1lw5V4uE9PawszyTPmEav2m0hGAfhLAhhLDAZOgrIm7DUX+k+7oc4nD6Ermt8hA==
   dependencies:
     "@rollup/plugin-node-resolve" "^13.0.0"
     "@rollup/plugin-replace" "^2.3.4"
@@ -73,22 +73,22 @@
     rollup-plugin-terser "^7.0.0"
     unified "^9.2.0"
 
-"@greenwood/plugin-google-analytics@^0.25.0-alpha.3":
-  version "0.25.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/@greenwood/plugin-google-analytics/-/plugin-google-analytics-0.25.0-alpha.3.tgz#13686631be527abb5564604c0033aa1b0eb10ba5"
-  integrity sha512-wI6MVS6bs9SJBNfEWBPc7s+H4jgphkpJiXWdpAXjK2a1bhrdl8YNITQJpgvwLzmNdgEdFA2sNkYgdL90JhbYiQ==
+"@greenwood/plugin-google-analytics@^0.25.0":
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/@greenwood/plugin-google-analytics/-/plugin-google-analytics-0.25.0.tgz#cd6f39d910b77aefef0f25a4f7cdfe78426112f1"
+  integrity sha512-JC4ZXqDR/6iJbyq+sNkokv1h1Hu6gXy2mDTkezWsgozqlPuaMAwUMZxxGqxx1sFfwQp8MorDLjP3bBG+YUgJSA==
 
-"@greenwood/plugin-import-css@^0.25.0-alpha.3":
-  version "0.25.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/@greenwood/plugin-import-css/-/plugin-import-css-0.25.0-alpha.3.tgz#81bc7fbfde762c7b395865e99b63993ba9102d01"
-  integrity sha512-8itszEDYN5sozYQXbj1TROQ5uuy1X7Ji1VgDEAfFIFWAOTItF4VWmFS7YMLJRQW7cVDDxOcAs3mVrTCEiKdTww==
+"@greenwood/plugin-import-css@^0.25.0":
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/@greenwood/plugin-import-css/-/plugin-import-css-0.25.0.tgz#ec3bb385f4154cff72235321cf5af238c0f69967"
+  integrity sha512-Z4y2wj5KaAVsQ/BiPqim3bGe6iB/n4N/q+pt/kqFDJab5aj7ROhRe4OoMOm5FWOc8g11u56aSw+qVf2oH1u3CA==
   dependencies:
     rollup-plugin-postcss "^4.0.2"
 
-"@greenwood/plugin-postcss@^0.25.0-alpha.3":
-  version "0.25.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/@greenwood/plugin-postcss/-/plugin-postcss-0.25.0-alpha.3.tgz#b8ec71e66637467dcabf2ffa1cbd751b47f56408"
-  integrity sha512-Rr6cEB1uLDOjX/7n08XVf/4fKPWsm4sMldo40Y5eUrACwAhrUC7jSBBor7J+wyrnYApB5GU+s5jkKAIdwL3sMA==
+"@greenwood/plugin-postcss@^0.25.0":
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/@greenwood/plugin-postcss/-/plugin-postcss-0.25.0.tgz#c66475a96822b64b50c7fb917ae381909e6c14b1"
+  integrity sha512-YfxjXjwGZ+HYT9m3wBUi8F0He2oei11i8nvxER2ftZsJYZgtc9mDxfupgi9J7nG9xsJXheCXPutTaiaHKqT7OA==
   dependencies:
     cssnano "^5.0.11"
     postcss-preset-env "^7.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -43,10 +43,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@greenwood/cli@^0.23.0":
-  version "0.23.0"
-  resolved "https://registry.yarnpkg.com/@greenwood/cli/-/cli-0.23.0.tgz#46a6a301de689a9053330f62469cb880ca3207ec"
-  integrity sha512-4IckraYIlTw1dOqi+0giJoq2czspiRYtlsok6kOqF6p0pJL0RPuEiwH4Hvr79IKQucpV24bHfLUMViDnatoNPQ==
+"@greenwood/cli@^0.25.0-alpha.0":
+  version "0.25.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@greenwood/cli/-/cli-0.25.0-alpha.0.tgz#b27d1b4cb43e8a6d5638915a181df25bbf8bdd63"
+  integrity sha512-GMfyovZD94ZIy9IcXgCUbH/VvuSHDPVt04Aabd+hHvrcmA4XtCYFtGiOKj7ePYuMISQqUgOWY04rfKLjzrdg3Q==
   dependencies:
     "@rollup/plugin-node-resolve" "^13.0.0"
     "@rollup/plugin-replace" "^2.3.4"
@@ -55,7 +55,7 @@
     acorn-walk "^8.0.0"
     commander "^2.20.0"
     cssnano "^5.0.11"
-    es-module-shims "^0.5.2"
+    es-module-shims "^1.2.0"
     front-matter "^4.0.2"
     koa "^2.13.0"
     livereload "^0.9.1"
@@ -74,22 +74,22 @@
     rollup-plugin-terser "^7.0.0"
     unified "^9.2.0"
 
-"@greenwood/plugin-google-analytics@^0.23.0":
-  version "0.23.0"
-  resolved "https://registry.yarnpkg.com/@greenwood/plugin-google-analytics/-/plugin-google-analytics-0.23.0.tgz#ba714a86eef7ee52a4067f75b174e412872f4a8b"
-  integrity sha512-kFsXMNVi428D6DRHlf3a3utGVxOIHxxk1V5IMQyyYT/yyO6H18/5/cYXyAQtLWGML53P/f+BLD/+nAVvaWLxgg==
+"@greenwood/plugin-google-analytics@^0.25.0-alpha.0":
+  version "0.25.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@greenwood/plugin-google-analytics/-/plugin-google-analytics-0.25.0-alpha.0.tgz#2151ea2900456e1eaea7a069bca9305c393a339f"
+  integrity sha512-fJ4WFEE4w/g0cY8K2aZvrU1QfFV+A0DGpPL7+7Xmh7WtBPkQ/XusBPnvOWyYsGi8K24iZuAn/1TOOC87pQFrQQ==
 
-"@greenwood/plugin-import-css@^0.23.0":
-  version "0.23.0"
-  resolved "https://registry.yarnpkg.com/@greenwood/plugin-import-css/-/plugin-import-css-0.23.0.tgz#29c232669956929b9ca8dd90575af6520fd1bf60"
-  integrity sha512-n/CmjTQGQm0uPCETjLAoQv8n2qSspAE5pVAzeK5DBeJPNi/jngaWMv3YbOgd8LuoKrghefdAB37KS5pZCgwubA==
+"@greenwood/plugin-import-css@^0.25.0-alpha.0":
+  version "0.25.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@greenwood/plugin-import-css/-/plugin-import-css-0.25.0-alpha.0.tgz#5c0efcadf8c97bb0627fd5ed6dcef021681f6aad"
+  integrity sha512-HEr9jeZ4ObTi7XH0T90o6TivMdlTFa9p3vTAR2nYIqbAnr9s91Zq6OLZB1ySBRGCnu+V75RZnqB7qwLHKFy7Xg==
   dependencies:
     rollup-plugin-postcss "^4.0.2"
 
-"@greenwood/plugin-postcss@^0.23.0":
-  version "0.23.0"
-  resolved "https://registry.yarnpkg.com/@greenwood/plugin-postcss/-/plugin-postcss-0.23.0.tgz#5dd30bf5db5e620ced95570d956c4d8e3d561fc7"
-  integrity sha512-wxStwYq6ZJdO1bFX35CfwRGcuJs1rvsRhmEmjvrfuo4eeJ9uGqIUeNpKdZ8kzKR6yWrMtp4gm78nK4+b4mpJBQ==
+"@greenwood/plugin-postcss@^0.25.0-alpha.0":
+  version "0.25.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@greenwood/plugin-postcss/-/plugin-postcss-0.25.0-alpha.0.tgz#3d7769996785851676985b87e1d24b1c25c3c80b"
+  integrity sha512-C5mJCTCwksWdvjJRDD/ImHOfFZQfbXfRe+DqU7NDISgCtsMX1toDtLjh7z9zKoGY5DPdO55AXTAVCSkebsLRew==
   dependencies:
     cssnano "^5.0.11"
     postcss-preset-env "^7.0.1"
@@ -923,10 +923,10 @@ entities@^2.0.0:
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.0.0.tgz#68d6084cab1b079767540d80e56a39b423e4abf4"
   integrity sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==
 
-es-module-shims@^0.5.2:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/es-module-shims/-/es-module-shims-0.5.2.tgz#9bea003e84a11bdc052b9f52464671176509f520"
-  integrity sha512-cXSy7EPyZc6Iq4AjyWXMqMURXgFguduPN7nxtfI0WsV4C83wNHrdxf0oxhzDPZU/8zB6YFllR24HMG/EBVN/GQ==
+es-module-shims@^1.2.0:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/es-module-shims/-/es-module-shims-1.5.2.tgz#dc78d80f89924bbaeee296aa01b364be05e061a1"
+  integrity sha512-1YzuTlSLnWwiWDcZqTlMJaQYJAViI6iYVB6ipLzdmtTH5ITHAbWYFO7rgG83RMyDZ33PptRwc3i/3RzFsCVDfg==
 
 escalade@^3.1.1:
   version "3.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -43,10 +43,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@greenwood/cli@^0.25.0-alpha.2":
-  version "0.25.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@greenwood/cli/-/cli-0.25.0-alpha.2.tgz#a9a62aca5603799c12944750a37418a70add5b01"
-  integrity sha512-VZBMCJBABXG3pa4nY4WAB2nr7hORuQcKhqMf6lPELt2mOu6aP3WnYFgxxV6VqDsdPzs/eHF8A2pBgLQrUIzkNw==
+"@greenwood/cli@^0.25.0-alpha.3":
+  version "0.25.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@greenwood/cli/-/cli-0.25.0-alpha.3.tgz#0ed44008d99196e10a0fbba6d1800bfbabf8d3e6"
+  integrity sha512-KHpaBnNhsJD3DjTf5I1ssZ8zsOVt+IHy+W/pJvf687oUbOTtVvXFdaRLHuEDUBwEq8L6Rqc0vMp9hDCXqKtVHw==
   dependencies:
     "@rollup/plugin-node-resolve" "^13.0.0"
     "@rollup/plugin-replace" "^2.3.4"
@@ -73,22 +73,22 @@
     rollup-plugin-terser "^7.0.0"
     unified "^9.2.0"
 
-"@greenwood/plugin-google-analytics@^0.25.0-alpha.2":
-  version "0.25.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@greenwood/plugin-google-analytics/-/plugin-google-analytics-0.25.0-alpha.2.tgz#9bc51fe7fc49afd6a42b387681590f471ed36baf"
-  integrity sha512-T9E4pplzkpkeLsc3mRBuucYGvyLPN9h1em4FOmqnAqK7uK6lj3hU8SjR1KGPmujo0z6o7jmYe3sCWbu+vEvUng==
+"@greenwood/plugin-google-analytics@^0.25.0-alpha.3":
+  version "0.25.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@greenwood/plugin-google-analytics/-/plugin-google-analytics-0.25.0-alpha.3.tgz#13686631be527abb5564604c0033aa1b0eb10ba5"
+  integrity sha512-wI6MVS6bs9SJBNfEWBPc7s+H4jgphkpJiXWdpAXjK2a1bhrdl8YNITQJpgvwLzmNdgEdFA2sNkYgdL90JhbYiQ==
 
-"@greenwood/plugin-import-css@^0.25.0-alpha.2":
-  version "0.25.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@greenwood/plugin-import-css/-/plugin-import-css-0.25.0-alpha.2.tgz#783fbd0ea0fb3b9f2077834da9c5ce0ba72d8f29"
-  integrity sha512-+3nFA3diP9fhFSX8wc8N1nSAdJP2ZPnC7c2+XfJaYAAo2F681nOwiFQYWBY3M5IFayR3ToJIQJsTbTqtqdqEUQ==
+"@greenwood/plugin-import-css@^0.25.0-alpha.3":
+  version "0.25.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@greenwood/plugin-import-css/-/plugin-import-css-0.25.0-alpha.3.tgz#81bc7fbfde762c7b395865e99b63993ba9102d01"
+  integrity sha512-8itszEDYN5sozYQXbj1TROQ5uuy1X7Ji1VgDEAfFIFWAOTItF4VWmFS7YMLJRQW7cVDDxOcAs3mVrTCEiKdTww==
   dependencies:
     rollup-plugin-postcss "^4.0.2"
 
-"@greenwood/plugin-postcss@^0.25.0-alpha.2":
-  version "0.25.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@greenwood/plugin-postcss/-/plugin-postcss-0.25.0-alpha.2.tgz#8e385ca0ccda5e2fe10645684883354e70388075"
-  integrity sha512-6/SYwSlfmeic44N3wSdJSVc/kh5/mMF4YIQQC1b0agiylcirQM1LgnEaHZooDX3J0dcC16eEgmY7ZL/0+EthBA==
+"@greenwood/plugin-postcss@^0.25.0-alpha.3":
+  version "0.25.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@greenwood/plugin-postcss/-/plugin-postcss-0.25.0-alpha.3.tgz#b8ec71e66637467dcabf2ffa1cbd751b47f56408"
+  integrity sha512-Rr6cEB1uLDOjX/7n08XVf/4fKPWsm4sMldo40Y5eUrACwAhrUC7jSBBor7J+wyrnYApB5GU+s5jkKAIdwL3sMA==
   dependencies:
     cssnano "^5.0.11"
     postcss-preset-env "^7.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -43,10 +43,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@greenwood/cli@^0.25.0-alpha.0":
-  version "0.25.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@greenwood/cli/-/cli-0.25.0-alpha.0.tgz#b27d1b4cb43e8a6d5638915a181df25bbf8bdd63"
-  integrity sha512-GMfyovZD94ZIy9IcXgCUbH/VvuSHDPVt04Aabd+hHvrcmA4XtCYFtGiOKj7ePYuMISQqUgOWY04rfKLjzrdg3Q==
+"@greenwood/cli@^0.25.0-alpha.1":
+  version "0.25.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@greenwood/cli/-/cli-0.25.0-alpha.1.tgz#a4e3392478bfd9d1e81cf88409433bc512078cad"
+  integrity sha512-sMd92MWcQ4AVEWhCpjp1fFgtxJ08RbRAy+F512rJ7czLOdsA/6HwKa70CbfWpObQ0Bv/t6/YXGE/V+DkT5rWkA==
   dependencies:
     "@rollup/plugin-node-resolve" "^13.0.0"
     "@rollup/plugin-replace" "^2.3.4"
@@ -64,7 +64,6 @@
     node-html-parser "^1.2.21"
     postcss "^8.3.11"
     postcss-import "^13.0.0"
-    puppeteer "^10.2.0"
     rehype-raw "^5.0.0"
     rehype-stringify "^8.0.0"
     remark-frontmatter "^2.0.0"
@@ -74,22 +73,22 @@
     rollup-plugin-terser "^7.0.0"
     unified "^9.2.0"
 
-"@greenwood/plugin-google-analytics@^0.25.0-alpha.0":
-  version "0.25.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@greenwood/plugin-google-analytics/-/plugin-google-analytics-0.25.0-alpha.0.tgz#2151ea2900456e1eaea7a069bca9305c393a339f"
-  integrity sha512-fJ4WFEE4w/g0cY8K2aZvrU1QfFV+A0DGpPL7+7Xmh7WtBPkQ/XusBPnvOWyYsGi8K24iZuAn/1TOOC87pQFrQQ==
+"@greenwood/plugin-google-analytics@^0.25.0-alpha.1":
+  version "0.25.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@greenwood/plugin-google-analytics/-/plugin-google-analytics-0.25.0-alpha.1.tgz#ab256ee71381ea6fb41e5b70842f48081949b4d5"
+  integrity sha512-EI4mjsyXMs7rZv2PpUbmFRvZl+cGwTmxepErbzRCaXn128aFhfpa31UgLSdecAazR+Ulw9TKRlJ3+PT5BKrteg==
 
-"@greenwood/plugin-import-css@^0.25.0-alpha.0":
-  version "0.25.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@greenwood/plugin-import-css/-/plugin-import-css-0.25.0-alpha.0.tgz#5c0efcadf8c97bb0627fd5ed6dcef021681f6aad"
-  integrity sha512-HEr9jeZ4ObTi7XH0T90o6TivMdlTFa9p3vTAR2nYIqbAnr9s91Zq6OLZB1ySBRGCnu+V75RZnqB7qwLHKFy7Xg==
+"@greenwood/plugin-import-css@^0.25.0-alpha.1":
+  version "0.25.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@greenwood/plugin-import-css/-/plugin-import-css-0.25.0-alpha.1.tgz#e01fe6a783369d343f966267d73af76d63a93a8d"
+  integrity sha512-uqlwZnOPC6iwUpmnW6Gp9Yq7+JWCNn5j6DfCTkHQHnGIpsxkVGsbzW8RCzTh734X+Pahel/40qzSIkhFvJRIOw==
   dependencies:
     rollup-plugin-postcss "^4.0.2"
 
-"@greenwood/plugin-postcss@^0.25.0-alpha.0":
-  version "0.25.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@greenwood/plugin-postcss/-/plugin-postcss-0.25.0-alpha.0.tgz#3d7769996785851676985b87e1d24b1c25c3c80b"
-  integrity sha512-C5mJCTCwksWdvjJRDD/ImHOfFZQfbXfRe+DqU7NDISgCtsMX1toDtLjh7z9zKoGY5DPdO55AXTAVCSkebsLRew==
+"@greenwood/plugin-postcss@^0.25.0-alpha.1":
+  version "0.25.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@greenwood/plugin-postcss/-/plugin-postcss-0.25.0-alpha.1.tgz#b63a79e56635a6bc05ae99548773d0ed6fc5a6a8"
+  integrity sha512-88Ub+RRBqWjZSbVywpWWXT7p8seEDdZVVil+afLxD5m9oMVwqnqFZ/dUZWuVUHSWDpy0VKi+gE21VxM/DCevJQ==
   dependencies:
     cssnano "^5.0.11"
     postcss-preset-env "^7.0.1"
@@ -184,9 +183,9 @@
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
 
 "@types/yauzl@^2.9.1":
-  version "2.9.1"
-  resolved "https://registry.yarnpkg.com/@types/yauzl/-/yauzl-2.9.1.tgz#d10f69f9f522eef3cf98e30afb684a1e1ec923af"
-  integrity sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/@types/yauzl/-/yauzl-2.9.2.tgz#c48e5d56aff1444409e39fa164b0b4d4552a7b7a"
+  integrity sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==
   dependencies:
     "@types/node" "*"
 
@@ -523,9 +522,9 @@ chokidar@^3.5.0:
     fsevents "~2.3.1"
 
 chownr@^1.1.1:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.3.tgz#42d837d5239688d55f303003a508230fa6727142"
-  integrity sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
+  integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
 
 co@^4.6.0:
   version "4.6.0"
@@ -764,7 +763,14 @@ csso@^4.2.0:
   dependencies:
     css-tree "^1.1.2"
 
-debug@4, debug@4.3.1:
+debug@4:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+  dependencies:
+    ms "2.1.2"
+
+debug@4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
   integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
@@ -2044,15 +2050,15 @@ minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
-  integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
-
 minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
   integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
+
+minimist@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 mixin-deep@^1.1.3:
   version "1.3.2"
@@ -2063,11 +2069,11 @@ mixin-deep@^1.1.3:
     is-extendable "^1.0.1"
 
 mkdirp@^0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
-  integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.6.tgz#7def03d2432dcae4ba1d611445c48396062255f6"
+  integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
   dependencies:
-    minimist "0.0.8"
+    minimist "^1.2.6"
 
 ms@2.0.0:
   version "2.0.0"
@@ -2889,9 +2895,9 @@ punycode@^2.1.0:
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
 puppeteer@^10.2.0:
-  version "10.2.0"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-10.2.0.tgz#7d8d7fda91e19a7cfd56986e0275448e6351849e"
-  integrity sha512-OR2CCHRashF+f30+LBOtAjK6sNtz2HEyTr5FqAvhf8lR/qB3uBRoIZOwQKgwoyZnMBsxX7ZdazlyBgGjpnkiMw==
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-10.4.0.tgz#a6465ff97fda0576c4ac29601406f67e6fea3dc7"
+  integrity sha512-2cP8mBoqnu5gzAVpbZ0fRaobBWZM8GEUF4I1F6WbgHrKV/rz7SX8PG2wMymZgD0wo0UBlg2FBPNxlF/xlqW6+w==
   dependencies:
     debug "4.3.1"
     devtools-protocol "0.0.901419"
@@ -2947,16 +2953,7 @@ readable-stream@^2.2.2, readable-stream@~2.3.6:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@^3.1.1:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.4.0.tgz#a51c26754658e0a3c21dbf59163bd45ba6f447fc"
-  integrity sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==
-  dependencies:
-    inherits "^2.0.3"
-    string_decoder "^1.1.1"
-    util-deprecate "^1.0.1"
-
-readable-stream@^3.4.0:
+readable-stream@^3.1.1, readable-stream@^3.4.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
@@ -3125,10 +3122,15 @@ safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-safe-buffer@^5.1.0, safe-buffer@~5.2.0:
+safe-buffer@^5.1.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
   integrity sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==
+
+safe-buffer@~5.2.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
 safe-identifier@^0.4.2:
   version "0.4.2"


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
N / A

## Summary of Changes
1. Upgrade Greenwood [**v0.25.0**](https://github.com/ProjectEvergreen/greenwood/releases/tag/v0.25.0)

## TODO
1. [x] need to remove `<meta>` from _greenwood.config.js_ and `<meta-outlet></meta-outlet>`
1. [x] component simple slider is broken now in production?  this due to the above