### PR TITLE
upgrade greenwood v0.26.0

### DIFF
--- a/greenwood.config.js
+++ b/greenwood.config.js
@@ -1,10 +1,9 @@
 import { greenwoodPluginGoogleAnalytics } from '@greenwood/plugin-google-analytics';
 import { greenwoodPluginImportCss } from '@greenwood/plugin-import-css';
 import { greenwoodPluginPostCss } from '@greenwood/plugin-postcss';
+import { greenwoodPluginRendererPuppeteer } from '@greenwood/plugin-renderer-puppeteer';
 
 export default {
-  prerender: true,
-
   plugins: [
     greenwoodPluginPostCss(),
     
@@ -12,6 +11,8 @@ export default {
 
     greenwoodPluginGoogleAnalytics({
       analyticsId: 'UA-147204327-2'
-    })
+    }),
+
+    ...greenwoodPluginRendererPuppeteer()
   ]
 };

--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
     "lit-element": "^2.4.0"
   },
   "devDependencies": {
-    "@greenwood/cli": "^0.26.0-alpha.1",
-    "@greenwood/plugin-google-analytics": "^0.26.0-alpha.1",
-    "@greenwood/plugin-import-css": "^0.26.0-alpha.1",
-    "@greenwood/plugin-postcss": "^0.26.0-alpha.1",
-    "@greenwood/plugin-renderer-puppeteer": "^0.26.0-alpha.1",
+    "@greenwood/cli": "^0.26.0",
+    "@greenwood/plugin-google-analytics": "^0.26.0",
+    "@greenwood/plugin-import-css": "^0.26.0",
+    "@greenwood/plugin-postcss": "^0.26.0",
+    "@greenwood/plugin-renderer-puppeteer": "^0.26.0",
     "eslint": "^8.4.0",
     "postcss-nested": "^4.1.2",
     "puppeteer": "^10.2.0",

--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
     "lit-element": "^2.4.0"
   },
   "devDependencies": {
-    "@greenwood/cli": "^0.25.0",
-    "@greenwood/plugin-google-analytics": "^0.25.0",
-    "@greenwood/plugin-import-css": "^0.25.0",
-    "@greenwood/plugin-postcss": "^0.25.0",
+    "@greenwood/cli": "^0.26.0-alpha.0",
+    "@greenwood/plugin-google-analytics": "^0.26.0-alpha.0",
+    "@greenwood/plugin-import-css": "^0.26.0-alpha.0",
+    "@greenwood/plugin-postcss": "^0.26.0-alpha.0",
     "eslint": "^8.4.0",
     "postcss-nested": "^4.1.2",
     "puppeteer": "^10.2.0",

--- a/package.json
+++ b/package.json
@@ -18,10 +18,11 @@
     "lit-element": "^2.4.0"
   },
   "devDependencies": {
-    "@greenwood/cli": "^0.26.0-alpha.0",
-    "@greenwood/plugin-google-analytics": "^0.26.0-alpha.0",
-    "@greenwood/plugin-import-css": "^0.26.0-alpha.0",
-    "@greenwood/plugin-postcss": "^0.26.0-alpha.0",
+    "@greenwood/cli": "^0.26.0-alpha.1",
+    "@greenwood/plugin-google-analytics": "^0.26.0-alpha.1",
+    "@greenwood/plugin-import-css": "^0.26.0-alpha.1",
+    "@greenwood/plugin-postcss": "^0.26.0-alpha.1",
+    "@greenwood/plugin-renderer-puppeteer": "^0.26.0-alpha.1",
     "eslint": "^8.4.0",
     "postcss-nested": "^4.1.2",
     "puppeteer": "^10.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -43,10 +43,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@greenwood/cli@^0.25.0":
-  version "0.25.0"
-  resolved "https://registry.yarnpkg.com/@greenwood/cli/-/cli-0.25.0.tgz#b0b29513258a3009bbe7e7cca92874a056501fb5"
-  integrity sha512-JIsgYMPTkdNgCN8GtG9Us/g1lw5V4uE9PawszyTPmEav2m0hGAfhLAhhLDAZOgrIm7DUX+k+7oc4nD6Ermt8hA==
+"@greenwood/cli@^0.26.0-alpha.0":
+  version "0.26.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@greenwood/cli/-/cli-0.26.0-alpha.0.tgz#94274d4d5138f1a93f3c8ab321b2c06350120b22"
+  integrity sha512-Wp/UHtuf+DbHVnSZMycGpUPe9Z1JznEmUfqlSJTCyKtWNv0pUDShNiDhwWEqm9x6aS098IjK6ybsTkJiuLxkoQ==
   dependencies:
     "@rollup/plugin-node-resolve" "^13.0.0"
     "@rollup/plugin-replace" "^2.3.4"
@@ -72,23 +72,24 @@
     rollup "^2.58.0"
     rollup-plugin-terser "^7.0.0"
     unified "^9.2.0"
+    wc-compiler "~0.3.1"
 
-"@greenwood/plugin-google-analytics@^0.25.0":
-  version "0.25.0"
-  resolved "https://registry.yarnpkg.com/@greenwood/plugin-google-analytics/-/plugin-google-analytics-0.25.0.tgz#cd6f39d910b77aefef0f25a4f7cdfe78426112f1"
-  integrity sha512-JC4ZXqDR/6iJbyq+sNkokv1h1Hu6gXy2mDTkezWsgozqlPuaMAwUMZxxGqxx1sFfwQp8MorDLjP3bBG+YUgJSA==
+"@greenwood/plugin-google-analytics@^0.26.0-alpha.0":
+  version "0.26.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@greenwood/plugin-google-analytics/-/plugin-google-analytics-0.26.0-alpha.0.tgz#8e9e8cb454ed2938a29fa4d5d5b236dfe2d40221"
+  integrity sha512-YF8WYWv2yv4lFG8RXeIGIxMZ86tuNxil6c5PdRizNk77D5BmVkSv40FpKy2gB9Ahdp4d7cw74rbA6bEYMjFd7Q==
 
-"@greenwood/plugin-import-css@^0.25.0":
-  version "0.25.0"
-  resolved "https://registry.yarnpkg.com/@greenwood/plugin-import-css/-/plugin-import-css-0.25.0.tgz#ec3bb385f4154cff72235321cf5af238c0f69967"
-  integrity sha512-Z4y2wj5KaAVsQ/BiPqim3bGe6iB/n4N/q+pt/kqFDJab5aj7ROhRe4OoMOm5FWOc8g11u56aSw+qVf2oH1u3CA==
+"@greenwood/plugin-import-css@^0.26.0-alpha.0":
+  version "0.26.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@greenwood/plugin-import-css/-/plugin-import-css-0.26.0-alpha.0.tgz#822e54b3f0912271286b8f1ad924109711df1835"
+  integrity sha512-/r4LPng2sMpVnLEP5UZedskwRSlbqxloOEhdENyBhK5BAp1TplhYOB8fk/nEr03TEkQhHgrbjJEXD0Spk9UCFA==
   dependencies:
     rollup-plugin-postcss "^4.0.2"
 
-"@greenwood/plugin-postcss@^0.25.0":
-  version "0.25.0"
-  resolved "https://registry.yarnpkg.com/@greenwood/plugin-postcss/-/plugin-postcss-0.25.0.tgz#c66475a96822b64b50c7fb917ae381909e6c14b1"
-  integrity sha512-YfxjXjwGZ+HYT9m3wBUi8F0He2oei11i8nvxER2ftZsJYZgtc9mDxfupgi9J7nG9xsJXheCXPutTaiaHKqT7OA==
+"@greenwood/plugin-postcss@^0.26.0-alpha.0":
+  version "0.26.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@greenwood/plugin-postcss/-/plugin-postcss-0.26.0-alpha.0.tgz#434cfd802531467a77909df4858964ff5e2e2518"
+  integrity sha512-buvaVxriuI4kcS6wtk02cxcbFH/9QMmDdY5BP/PL6dqo1GPxR7yCn2Y85OsP/DL17D3oIno9cDCy5qu0R/9hDw==
   dependencies:
     cssnano "^5.0.11"
     postcss-preset-env "^7.0.1"
@@ -212,6 +213,11 @@ acorn-walk@^8.0.0:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.0.2.tgz#d4632bfc63fd93d0f15fd05ea0e984ffd3f5a8c3"
   integrity sha512-+bpA9MJsHdZ4bgfDcpk0ozQyhhVct7rzOmO0s1IIr0AGGgKBljss8n2zp11rRP2wid5VGeh04CgeKzgat5/25A==
 
+acorn-walk@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
+  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
+
 acorn@^8.0.1:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.1.0.tgz#52311fd7037ae119cbb134309e901aa46295b3fe"
@@ -221,6 +227,11 @@ acorn@^8.6.0:
   version "8.6.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.6.0.tgz#e3692ba0eb1a0c83eaa4f37f5fa7368dd7142895"
   integrity sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw==
+
+acorn@^8.7.0:
+  version "8.7.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.1.tgz#0197122c843d1bf6d0a5e83220a788f278f63c30"
+  integrity sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==
 
 agent-base@6:
   version "6.0.2"
@@ -2254,7 +2265,7 @@ parse-entities@^2.0.0:
     is-decimal "^1.0.0"
     is-hexadecimal "^1.0.0"
 
-parse5@^6.0.0:
+parse5@^6.0.0, parse5@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
   integrity sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
@@ -3587,6 +3598,15 @@ vfile@^4.0.0:
     is-buffer "^2.0.0"
     unist-util-stringify-position "^2.0.0"
     vfile-message "^2.0.0"
+
+wc-compiler@~0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/wc-compiler/-/wc-compiler-0.3.1.tgz#fedd4249947092ef8d30c41156911a2891c7cef4"
+  integrity sha512-hY72m2EX6WW9k8+kXzrOCxyJetaTRKmGODnW3Ftl2u1d5pOw6mXSZkBI6/5SEw07jbQK/CLs/Tem/SF2PBO0mQ==
+  dependencies:
+    acorn "^8.7.0"
+    acorn-walk "^8.2.0"
+    parse5 "^6.0.1"
 
 web-namespaces@^1.0.0:
   version "1.1.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -43,14 +43,13 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@greenwood/cli@^0.26.0-alpha.0":
-  version "0.26.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@greenwood/cli/-/cli-0.26.0-alpha.0.tgz#94274d4d5138f1a93f3c8ab321b2c06350120b22"
-  integrity sha512-Wp/UHtuf+DbHVnSZMycGpUPe9Z1JznEmUfqlSJTCyKtWNv0pUDShNiDhwWEqm9x6aS098IjK6ybsTkJiuLxkoQ==
+"@greenwood/cli@^0.26.0-alpha.1":
+  version "0.26.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@greenwood/cli/-/cli-0.26.0-alpha.1.tgz#1b62c8753f8a95dca4ea02445e370f0cf6b19d56"
+  integrity sha512-T26/cP3cbqC5hUTnnv3O9DFmSfOb2cisrehLi0zof5yMLiL/rHAQbTbCBQ0+xiPPUHwnSKNQRPklHE/yNCTqOQ==
   dependencies:
     "@rollup/plugin-node-resolve" "^13.0.0"
     "@rollup/plugin-replace" "^2.3.4"
-    "@webcomponents/webcomponentsjs" "^2.6.0"
     acorn "^8.0.1"
     acorn-walk "^8.0.0"
     commander "^2.20.0"
@@ -72,27 +71,35 @@
     rollup "^2.58.0"
     rollup-plugin-terser "^7.0.0"
     unified "^9.2.0"
-    wc-compiler "~0.3.1"
+    wc-compiler "~0.4.0"
 
-"@greenwood/plugin-google-analytics@^0.26.0-alpha.0":
-  version "0.26.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@greenwood/plugin-google-analytics/-/plugin-google-analytics-0.26.0-alpha.0.tgz#8e9e8cb454ed2938a29fa4d5d5b236dfe2d40221"
-  integrity sha512-YF8WYWv2yv4lFG8RXeIGIxMZ86tuNxil6c5PdRizNk77D5BmVkSv40FpKy2gB9Ahdp4d7cw74rbA6bEYMjFd7Q==
+"@greenwood/plugin-google-analytics@^0.26.0-alpha.1":
+  version "0.26.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@greenwood/plugin-google-analytics/-/plugin-google-analytics-0.26.0-alpha.1.tgz#f4d8196b70e6efcfba9d48614645f603c6c67f81"
+  integrity sha512-570q8dmMJwj/JcdCl2Em+X0mTMc5FeK8088C+IeNWQcLOOjfhYMb2lkBYlElSfIx3rRS7haiA0uS9xVPnjzpcA==
 
-"@greenwood/plugin-import-css@^0.26.0-alpha.0":
-  version "0.26.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@greenwood/plugin-import-css/-/plugin-import-css-0.26.0-alpha.0.tgz#822e54b3f0912271286b8f1ad924109711df1835"
-  integrity sha512-/r4LPng2sMpVnLEP5UZedskwRSlbqxloOEhdENyBhK5BAp1TplhYOB8fk/nEr03TEkQhHgrbjJEXD0Spk9UCFA==
+"@greenwood/plugin-import-css@^0.26.0-alpha.1":
+  version "0.26.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@greenwood/plugin-import-css/-/plugin-import-css-0.26.0-alpha.1.tgz#27e3f50889a9e880b2c8dc5f6c4cc79f363b0507"
+  integrity sha512-kuaDaFBm6+wHDn9+bB1SYnZuJ+G/Sj5zheMNDB8X5wHv5HqGAfW6Ic/CzW0I6H7gEbFqumYhr/+TKVEKRicXIQ==
   dependencies:
     rollup-plugin-postcss "^4.0.2"
 
-"@greenwood/plugin-postcss@^0.26.0-alpha.0":
-  version "0.26.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@greenwood/plugin-postcss/-/plugin-postcss-0.26.0-alpha.0.tgz#434cfd802531467a77909df4858964ff5e2e2518"
-  integrity sha512-buvaVxriuI4kcS6wtk02cxcbFH/9QMmDdY5BP/PL6dqo1GPxR7yCn2Y85OsP/DL17D3oIno9cDCy5qu0R/9hDw==
+"@greenwood/plugin-postcss@^0.26.0-alpha.1":
+  version "0.26.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@greenwood/plugin-postcss/-/plugin-postcss-0.26.0-alpha.1.tgz#026a05f0bc3c95963ff55b40b714216a51c2c2c0"
+  integrity sha512-wueJeFW/zy76cDbCf0C3+/515DTSsCNtbFQnWYCjbMIGZKd+MkzTd2okClz88TCQZNcnqiw02oTFKdhKu7NEDw==
   dependencies:
     cssnano "^5.0.11"
     postcss-preset-env "^7.0.1"
+
+"@greenwood/plugin-renderer-puppeteer@^0.26.0-alpha.1":
+  version "0.26.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@greenwood/plugin-renderer-puppeteer/-/plugin-renderer-puppeteer-0.26.0-alpha.1.tgz#832316e5a02d001a4c7534ad80a6153ba134f3ea"
+  integrity sha512-Bs4KFhUBchrXy3Vmc9777LuUa8m5w6E8HEgdXar7VbBGnG+K2v9sMTo0E0iD/Y5krd76q9pT79V+wKKP+XIRFw==
+  dependencies:
+    "@webcomponents/webcomponentsjs" "^2.6.0"
+    puppeteer "^15.3.2"
 
 "@humanwhocodes/config-array@^0.9.2":
   version "0.9.2"
@@ -650,6 +657,13 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
+cross-fetch@3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
+  integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
+  dependencies:
+    node-fetch "2.6.7"
+
 cross-spawn@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -774,7 +788,7 @@ csso@^4.2.0:
   dependencies:
     css-tree "^1.1.2"
 
-debug@4:
+debug@4, debug@4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -843,6 +857,11 @@ destroy@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
   integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
+
+devtools-protocol@0.0.1011705:
+  version "0.0.1011705"
+  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.1011705.tgz#2582ed29f84848df83fba488122015540a744539"
+  integrity sha512-OKvTvu9n3swmgYshvsyVHYX0+aPzCoYUnyXUacfQMmFtBtBKewV/gT4I9jkAbpTqtTi2E4S9MXLlvzBDUlqg0Q==
 
 devtools-protocol@0.0.901419:
   version "0.0.901419"
@@ -1465,6 +1484,14 @@ https-proxy-agent@5.0.0:
     agent-base "6"
     debug "4"
 
+https-proxy-agent@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
+  integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
+  dependencies:
+    agent-base "6"
+    debug "4"
+
 icss-replace-symbols@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz#06ea6f83679a7749e386cfe1fe812ae5db223ded"
@@ -2079,6 +2106,11 @@ mixin-deep@^1.1.3:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
+mkdirp-classic@^0.5.2:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
+  integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
+
 mkdirp@^0.5.1:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.6.tgz#7def03d2432dcae4ba1d611445c48396062255f6"
@@ -2115,6 +2147,13 @@ node-fetch@2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
+node-fetch@2.6.7:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
 
 node-fetch@^2.6.1:
   version "2.6.6"
@@ -2870,7 +2909,7 @@ progress@2.0.1:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.1.tgz#c9242169342b1c29d275889c95734621b1952e31"
   integrity sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==
 
-progress@^2.0.0:
+progress@2.0.3, progress@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
@@ -2922,6 +2961,24 @@ puppeteer@^10.2.0:
     tar-fs "2.0.0"
     unbzip2-stream "1.3.3"
     ws "7.4.6"
+
+puppeteer@^15.3.2:
+  version "15.4.0"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-15.4.0.tgz#31f043ee64cc4e1b5cbe99ad900653aab4afb186"
+  integrity sha512-wxJRbofjaycCaQ9fhABlToJobrjxlABiFi6NvdkOPVJMYFblxDlDTjkg+b6bZYi7xN+lEXn84GBZsA5DYb3wfw==
+  dependencies:
+    cross-fetch "3.1.5"
+    debug "4.3.4"
+    devtools-protocol "0.0.1011705"
+    extract-zip "2.0.1"
+    https-proxy-agent "5.0.1"
+    pkg-dir "4.2.0"
+    progress "2.0.3"
+    proxy-from-env "1.1.0"
+    rimraf "3.0.2"
+    tar-fs "2.1.1"
+    unbzip2-stream "1.4.3"
+    ws "8.8.0"
 
 quote-unquote@^1.0.0:
   version "1.0.0"
@@ -3353,7 +3410,17 @@ tar-fs@2.0.0:
     pump "^3.0.0"
     tar-stream "^2.0.0"
 
-tar-stream@^2.0.0:
+tar-fs@2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.1.tgz#489a15ab85f1f0befabb370b7de4f9eb5cbe8784"
+  integrity sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==
+  dependencies:
+    chownr "^1.1.1"
+    mkdirp-classic "^0.5.2"
+    pump "^3.0.0"
+    tar-stream "^2.1.4"
+
+tar-stream@^2.0.0, tar-stream@^2.1.4:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.2.0.tgz#acad84c284136b060dc3faa64474aa9aebd77287"
   integrity sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==
@@ -3474,6 +3541,14 @@ unbzip2-stream@1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/unbzip2-stream/-/unbzip2-stream-1.3.3.tgz#d156d205e670d8d8c393e1c02ebd506422873f6a"
   integrity sha512-fUlAF7U9Ah1Q6EieQ4x4zLNejrRvDWUYmxXUpN3uziFYCHapjWFaCAnreY9bGgxzaMCFAPPpYNng57CypwJVhg==
+  dependencies:
+    buffer "^5.2.1"
+    through "^2.3.8"
+
+unbzip2-stream@1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz#b0da04c4371311df771cdc215e87f2130991ace7"
+  integrity sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==
   dependencies:
     buffer "^5.2.1"
     through "^2.3.8"
@@ -3599,10 +3674,10 @@ vfile@^4.0.0:
     unist-util-stringify-position "^2.0.0"
     vfile-message "^2.0.0"
 
-wc-compiler@~0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/wc-compiler/-/wc-compiler-0.3.1.tgz#fedd4249947092ef8d30c41156911a2891c7cef4"
-  integrity sha512-hY72m2EX6WW9k8+kXzrOCxyJetaTRKmGODnW3Ftl2u1d5pOw6mXSZkBI6/5SEw07jbQK/CLs/Tem/SF2PBO0mQ==
+wc-compiler@~0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/wc-compiler/-/wc-compiler-0.4.1.tgz#7a970760f6decaedfba4d99939d590b43a5ad6a2"
+  integrity sha512-TmjrquaS83Ra+q58L7fhHY2sJPM22oFRbrAnC6Djvq5Ex+qc/iAn/jg4pXRgLzWHlhLwI+6Z8C3sBpINFq0O4Q==
   dependencies:
     acorn "^8.7.0"
     acorn-walk "^8.2.0"
@@ -3647,6 +3722,11 @@ ws@7.4.6, ws@^7.4.3:
   version "7.4.6"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
   integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
+
+ws@8.8.0:
+  version "8.8.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.8.0.tgz#8e71c75e2f6348dbf8d78005107297056cb77769"
+  integrity sha512-JDAgSYQ1ksuwqfChJusw1LSJ8BizJ2e/vVu5Lxjq3YvNJNlROv1ui4i+c/kUUrPheBvQl4c5UbERhTwKa6QBJQ==
 
 xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -43,10 +43,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@greenwood/cli@^0.26.0-alpha.1":
-  version "0.26.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@greenwood/cli/-/cli-0.26.0-alpha.1.tgz#1b62c8753f8a95dca4ea02445e370f0cf6b19d56"
-  integrity sha512-T26/cP3cbqC5hUTnnv3O9DFmSfOb2cisrehLi0zof5yMLiL/rHAQbTbCBQ0+xiPPUHwnSKNQRPklHE/yNCTqOQ==
+"@greenwood/cli@^0.26.0":
+  version "0.26.0"
+  resolved "https://registry.yarnpkg.com/@greenwood/cli/-/cli-0.26.0.tgz#18784c9d435a47a59381a9abf32b2f82652a54b5"
+  integrity sha512-CcxNBxwQGAnu8dnbcsx51EThoHQxr49J0ZCfhXmaB/DvhZvMwXYeJ6ihnWAmSLhlgGr087qJFojyqo3zi3jBtg==
   dependencies:
     "@rollup/plugin-node-resolve" "^13.0.0"
     "@rollup/plugin-replace" "^2.3.4"
@@ -71,32 +71,32 @@
     rollup "^2.58.0"
     rollup-plugin-terser "^7.0.0"
     unified "^9.2.0"
-    wc-compiler "~0.4.0"
+    wc-compiler "~0.5.0"
 
-"@greenwood/plugin-google-analytics@^0.26.0-alpha.1":
-  version "0.26.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@greenwood/plugin-google-analytics/-/plugin-google-analytics-0.26.0-alpha.1.tgz#f4d8196b70e6efcfba9d48614645f603c6c67f81"
-  integrity sha512-570q8dmMJwj/JcdCl2Em+X0mTMc5FeK8088C+IeNWQcLOOjfhYMb2lkBYlElSfIx3rRS7haiA0uS9xVPnjzpcA==
+"@greenwood/plugin-google-analytics@^0.26.0":
+  version "0.26.0"
+  resolved "https://registry.yarnpkg.com/@greenwood/plugin-google-analytics/-/plugin-google-analytics-0.26.0.tgz#aaac525f9370338af5bef0127c1de90c3267ef77"
+  integrity sha512-9Xmf2UMcb51qICYoEWVSYrYhtA4GJVJKrQL3OKcO7Lh8coRdCG5rfIunJn3eIB/TREI93zzOq1n07aRPKiyGrw==
 
-"@greenwood/plugin-import-css@^0.26.0-alpha.1":
-  version "0.26.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@greenwood/plugin-import-css/-/plugin-import-css-0.26.0-alpha.1.tgz#27e3f50889a9e880b2c8dc5f6c4cc79f363b0507"
-  integrity sha512-kuaDaFBm6+wHDn9+bB1SYnZuJ+G/Sj5zheMNDB8X5wHv5HqGAfW6Ic/CzW0I6H7gEbFqumYhr/+TKVEKRicXIQ==
+"@greenwood/plugin-import-css@^0.26.0":
+  version "0.26.0"
+  resolved "https://registry.yarnpkg.com/@greenwood/plugin-import-css/-/plugin-import-css-0.26.0.tgz#64912baae0a069845ebfed6aa18398f8b9310ddf"
+  integrity sha512-cuJDa8klePyzaMK/2mHyzhEgFanp8f7TGLBGSrmXwqTe8JvHdztb6jhMO0v8o16p4mmwgsM3fzUO9XVGIKEBNw==
   dependencies:
     rollup-plugin-postcss "^4.0.2"
 
-"@greenwood/plugin-postcss@^0.26.0-alpha.1":
-  version "0.26.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@greenwood/plugin-postcss/-/plugin-postcss-0.26.0-alpha.1.tgz#026a05f0bc3c95963ff55b40b714216a51c2c2c0"
-  integrity sha512-wueJeFW/zy76cDbCf0C3+/515DTSsCNtbFQnWYCjbMIGZKd+MkzTd2okClz88TCQZNcnqiw02oTFKdhKu7NEDw==
+"@greenwood/plugin-postcss@^0.26.0":
+  version "0.26.0"
+  resolved "https://registry.yarnpkg.com/@greenwood/plugin-postcss/-/plugin-postcss-0.26.0.tgz#b3624035d4df364ba1e1cd15fe799ef1eb3cfd75"
+  integrity sha512-/doigMNkiOjq6sTSAolABQ0u4RRD49+GhvAPbpmH7loSyztTZGcwfdKiDqTIn7VNBtZBxTPDajGILejx4Ebibw==
   dependencies:
     cssnano "^5.0.11"
     postcss-preset-env "^7.0.1"
 
-"@greenwood/plugin-renderer-puppeteer@^0.26.0-alpha.1":
-  version "0.26.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@greenwood/plugin-renderer-puppeteer/-/plugin-renderer-puppeteer-0.26.0-alpha.1.tgz#832316e5a02d001a4c7534ad80a6153ba134f3ea"
-  integrity sha512-Bs4KFhUBchrXy3Vmc9777LuUa8m5w6E8HEgdXar7VbBGnG+K2v9sMTo0E0iD/Y5krd76q9pT79V+wKKP+XIRFw==
+"@greenwood/plugin-renderer-puppeteer@^0.26.0":
+  version "0.26.0"
+  resolved "https://registry.yarnpkg.com/@greenwood/plugin-renderer-puppeteer/-/plugin-renderer-puppeteer-0.26.0.tgz#9dfbe8a887419638935b263cb9844fd61bff2062"
+  integrity sha512-hGW7cWIhfsBp8BkdpdERbtKzp+Q331+jI1HSMMrzBLV2UmryPr6qtbUW8qgT6iYwj4yCxAlzMO5q4mc0spsYGA==
   dependencies:
     "@webcomponents/webcomponentsjs" "^2.6.0"
     puppeteer "^15.3.2"
@@ -3674,10 +3674,10 @@ vfile@^4.0.0:
     unist-util-stringify-position "^2.0.0"
     vfile-message "^2.0.0"
 
-wc-compiler@~0.4.0:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/wc-compiler/-/wc-compiler-0.4.1.tgz#7a970760f6decaedfba4d99939d590b43a5ad6a2"
-  integrity sha512-TmjrquaS83Ra+q58L7fhHY2sJPM22oFRbrAnC6Djvq5Ex+qc/iAn/jg4pXRgLzWHlhLwI+6Z8C3sBpINFq0O4Q==
+wc-compiler@~0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/wc-compiler/-/wc-compiler-0.5.0.tgz#869739ba765e41ac699b08a5991c52231ef2fbe0"
+  integrity sha512-ScHbrtd81cvMEg8tn7L/iSc1WhckNKIB77VGhZYxMNELHmgQdMuC/r36E/LhAHdqAJYxi4y77DXmU56BZzeBng==
   dependencies:
     acorn "^8.7.0"
     acorn-walk "^8.2.0"


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
Greenwood [**v0.26.0**](https://github.com/ProjectEvergreen/greenwood/releases/tag/v0.26.0) release

## Summary of Changes
1. Upgrade latest version

## TODO
Need to think of how to cut this over to WCC since we are using `HTMLElement` here.  However, I think it would depend on one or more of the following 
1. We drop usage of CSS-in-JS w/PostCSS (ideally)
1. Wait for https://github.com/ProjectEvergreen/greenwood/issues/878 and / or polyfill CSS on the server side - https://github.com/ProjectEvergreen/greenwood/issues/923
1. Constructable Stylesheets?

I think we would have to drop support for or update [**component-simple-slider**](https://github.com/ProjectEvergreen/component-simple-slider) based on whatever approach we take.